### PR TITLE
Fix byte order issue with double values (latitude/longitude fields)

### DIFF
--- a/Sources/MaxMindDBSwift/GeoIP2.swift
+++ b/Sources/MaxMindDBSwift/GeoIP2.swift
@@ -326,7 +326,10 @@ public final class GeoIP2 {
                 value = try parseString(data: valueData)
                 current = valuePtr.pointee.next
             case UInt32(MMDB_DATA_TYPE_DOUBLE):
-                value = valueData.double_value
+                // Swap byte order to fix endianness issue
+                let bits = valueData.double_value.bitPattern
+                let swapped = bits.byteSwapped
+                value = Double(bitPattern: swapped)
                 current = valuePtr.pointee.next
             case UInt32(MMDB_DATA_TYPE_UINT16):
                 value = valueData.uint16


### PR DESCRIPTION
The MaxMind database stores doubles in big-endian format, but they were being read directly without byte-order conversion, causing latitude and longitude values to appear as garbage (-2.286405743367628e+180 instead of -33.8688)